### PR TITLE
updated sources to match exaNBody/main recent changes

### DIFF
--- a/data/config/config_move_particles.msp
+++ b/data/config/config_move_particles.msp
@@ -22,11 +22,11 @@ rebuild_amr:
 chunk_neighbors_contact:
   config:
     free_scratch_memory: true
-    build_particle_offset: false
+    build_particle_offset: true
     subcell_compaction: true
     scratch_mem_per_cell: 1048576
     stream_prealloc_factor: 1.05
-    chunk_size: 2
+    chunk_size: 1
 
 chunk_neighbors_impl: 
 #  - chunk_neighbors

--- a/src/friction/update_nbh_friction.cpp
+++ b/src/friction/update_nbh_friction.cpp
@@ -120,12 +120,12 @@ namespace exaDEM
       if( domain->xform_is_identity() )
       {
         auto optional = make_compute_pair_optional_args( nbh_it, cp_friction, NullXForm{}, cp_locks );
-        compute_cell_particle_pairs( *grid, *rcut, false /*no ghost*/, optional, make_default_pair_buffer(), update_op , compute_fields );
+        compute_cell_particle_pairs( *grid, *rcut, false /*no ghost*/, optional, make_default_pair_buffer(), update_op , compute_fields , parallel_execution_context() );
       }
       else
       {
         auto optional = make_compute_pair_optional_args( nbh_it, cp_friction , LinearXForm{ domain->xform() }, cp_locks );
-        compute_cell_particle_pairs( *grid, *rcut, false /*no ghost*/, optional, make_default_pair_buffer(), update_op , compute_fields );
+        compute_cell_particle_pairs( *grid, *rcut, false /*no ghost*/, optional, make_default_pair_buffer(), update_op , compute_fields , parallel_execution_context() );
       }
 
     }

--- a/src/numericalscheme/combined_compute_epilog.cpp
+++ b/src/numericalscheme/combined_compute_epilog.cpp
@@ -14,7 +14,7 @@
 #include <exaDEM/angular_acceleration.h>
 #include <exaDEM/angular_velocity.h>
 #include <exanb/defbox/push_vec3_1st_order.h>
-#include <exanb/defbox/push_vec3_1st_order_xform.h>
+//#include <exanb/defbox/push_vec3_1st_order_xform.h>
 
 namespace exaDEM
 {

--- a/src/numericalscheme/combined_compute_prolog.cpp
+++ b/src/numericalscheme/combined_compute_prolog.cpp
@@ -13,9 +13,9 @@
 
 #include <exaDEM/push_to_quaternion.h>
 #include <exanb/defbox/push_vec3_2nd_order.h>
-#include <exanb/defbox/push_vec3_2nd_order_xform.h>
+//#include <exanb/defbox/push_vec3_2nd_order_xform.h>
 #include <exanb/defbox/push_vec3_1st_order.h>
-#include <exanb/defbox/push_vec3_1st_order_xform.h>
+//#include <exanb/defbox/push_vec3_1st_order_xform.h>
 
 namespace exaDEM
 {


### PR DESCRIPTION
1) suppressed 2 #includes :
#include <exanb/defbox/push_vec3_2nd_order_xform.h>
and
#include <exanb/defbox/push_vec3_1st_order_xform.h>
, their content is included directly in 
#include <exanb/defbox/push_vec3_2nd_order.h>
and
#include <exanb/defbox/push_vec3_1st_order.h>

2) added parallel_execution_context() as last argument of compute_cell_particle_pairs