### PR TITLE
Add the operator check_consistency_grid_classifier 

### DIFF
--- a/data/config/config_globals.msp
+++ b/data/config/config_globals.msp
@@ -24,6 +24,7 @@ global:
   trigger_generator: false
   analysis_interaction_dump_frequency: -1 
   analysis_dump_stress_tensor_frequency: -1
+  active_interaction_checker: false
 
 # default grid variant we use
 grid_flavor: grid_flavor_dem

--- a/data/config/config_iteration_dump.msp
+++ b/data/config/config_iteration_dump.msp
@@ -59,9 +59,16 @@ dump_stress_tensor_if_triggered:
     - global_stress_tensor
     - write_stress_tensor
 
+interaction_consistency_checker:
+  condition: active_interaction_checker
+  body:
+    - check_consistency_grid_classifier:
+        verbosity: true
+
 compress_data: 
   - unclassify_interactions
   - compress_interaction
+  - interaction_consistency_checker
 
 dump_data_particles:
   - timestep_paraview_file: "CheckpointFiles/exadem_%010d.dump"

--- a/data/config/config_polyhedra.msp
+++ b/data/config/config_polyhedra.msp
@@ -13,7 +13,6 @@ chunk_neighbors_impl:
   - chunk_neighbors_contact
   - nbh_polyhedron
   - classify_interactions
-  - resize_particle_locks
 
 migrate_particles:
   - migrate_cell_particles_interaction

--- a/example/polyhedra/aggregate/regression_test_aggregate.msp
+++ b/example/polyhedra/aggregate/regression_test_aggregate.msp
@@ -7,3 +7,4 @@ global:
   simulation_generator_frequency: -1 
   dt: 0.001 s
   rcut_inc: 0.03 m 
+  active_interaction_checker: true

--- a/example/polyhedra/balls/regression-test-balls.msp
+++ b/example/polyhedra/balls/regression-test-balls.msp
@@ -5,3 +5,4 @@ global:
   simulation_paraview_frequency: -1
   dt: 0.0001 s 
   rcut_inc: 0.1
+  active_interaction_checker: true

--- a/example/polyhedra/defbox/regression_test_shear_with_xform_dem.msp
+++ b/example/polyhedra/defbox/regression_test_shear_with_xform_dem.msp
@@ -6,3 +6,4 @@ global:
   remove_velocity_bias_frequency: 200
   dt: 0.0001 s 
   rcut_inc: 0.1
+  active_interaction_checker: true

--- a/example/polyhedra/funnel/regression_test_funnel.msp
+++ b/example/polyhedra/funnel/regression_test_funnel.msp
@@ -18,3 +18,4 @@ global:
   simulation_paraview_frequency: -1
   dt: 0.0001 s 
   rcut_inc: 0.2 m
+  active_interaction_checker: true

--- a/example/polyhedra/rescale_shape/regression_test_common.msp
+++ b/example/polyhedra/rescale_shape/regression_test_common.msp
@@ -6,4 +6,4 @@ global:
   simulation_paraview_frequency: -1
   dt: 0.00005 s
   rcut_inc: 0.05 m
-
+  active_interaction_checker: true

--- a/example/polyhedra/samoyed/regression_test_samoyed.msp
+++ b/example/polyhedra/samoyed/regression_test_samoyed.msp
@@ -7,3 +7,4 @@ global:
   simulation_generator_frequency: -1 
   dt: 0.00005 s 
   rcut_inc: 0.03 m
+  active_interaction_checker: true

--- a/example/polyhedra/stl_cylinder/regression_test_stl_cylinder_multi_shp.msp
+++ b/example/polyhedra/stl_cylinder/regression_test_stl_cylinder_multi_shp.msp
@@ -20,3 +20,4 @@ global:
   simulation_paraview_frequency: -1
   dt: 0.0001 s # x100 for testing 
   rcut_inc: 0.05 m
+  active_interaction_checker: true

--- a/example/spheres/ball/regression-test-driver-ball-linear.msp
+++ b/example/spheres/ball/regression-test-driver-ball-linear.msp
@@ -5,3 +5,4 @@ global:
   simulation_paraview_frequency: -1
   dt: 0.0005 s 
   rcut_inc: 0.4
+  active_interaction_checker: true

--- a/example/spheres/ball/regression-test-driver-ball-radial-stress.msp
+++ b/example/spheres/ball/regression-test-driver-ball-radial-stress.msp
@@ -5,3 +5,4 @@ global:
   simulation_paraview_frequency: -1
   dt: 0.00005 s 
   rcut_inc: 0.4
+  active_interaction_checker: true

--- a/example/spheres/ball/regression-test-driver-ball-stationary.msp
+++ b/example/spheres/ball/regression-test-driver-ball-stationary.msp
@@ -5,3 +5,4 @@ global:
   simulation_paraview_frequency: -1
   dt: 0.0005 s 
   rcut_inc: 0.4
+  active_interaction_checker: true

--- a/example/spheres/ball/regression-test-driver-ball-tabulated.msp
+++ b/example/spheres/ball/regression-test-driver-ball-tabulated.msp
@@ -5,3 +5,4 @@ global:
   simulation_paraview_frequency: -1
   dt: 0.0005 s 
   rcut_inc: 0.4
+  active_interaction_checker: true

--- a/example/spheres/cylinder_stl/regression_test_cylinder_stl.msp
+++ b/example/spheres/cylinder_stl/regression_test_cylinder_stl.msp
@@ -5,3 +5,4 @@ global:
   simulation_paraview_frequency: -1
   dt: 0.0001 s 
   rcut_inc: 0.4
+  active_interaction_checker: true

--- a/src/interaction/check_consistency_grid_classifier.cpp
+++ b/src/interaction/check_consistency_grid_classifier.cpp
@@ -1,0 +1,142 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+#include <onika/scg/operator.h>
+#include <onika/scg/operator_slot.h>
+#include <onika/scg/operator_factory.h>
+#include <exanb/core/make_grid_variant_operator.h>
+#include <exanb/core/parallel_grid_algorithm.h>
+#include <exanb/core/grid.h>
+
+#include <memory>
+#include <array>
+
+#include <exaDEM/contact_force_parameters.h>
+#include <exaDEM/compute_contact_force.h>
+#include <exaDEM/interaction/interaction.hpp>
+#include <exaDEM/classifier/interactionSOA.hpp>
+#include <exaDEM/classifier/interactionAOS.hpp>
+#include <exaDEM/interaction/grid_cell_interaction.hpp>
+#include <exaDEM/classifier/classifier.hpp>
+
+namespace exaDEM
+{
+  using namespace exanb;
+  class CheckConsistencyGridClassifier : public OperatorNode
+  {
+    // attributes processed during computation
+    using ComputeFields = FieldSet<field::_vrot, field::_arot>;
+    static constexpr ComputeFields compute_field_set{};
+
+		ADD_SLOT(GridCellParticleInteraction, ges, INPUT_OUTPUT, REQUIRED,
+				DocString{"List of particle interactions within each grid cell"});
+		ADD_SLOT(Classifier<InteractionSOA>, ic, INPUT,
+				DocString{"Interaction lists, classified and grouped by interaction type"});
+		ADD_SLOT(bool, verbosity, PRIVATE, false,
+				DocString{"Enable detailed messages to verify consistency between the classifier and GridCellParticleInteraction"});
+
+		public:
+		inline std::string documentation() const override final
+		{
+			return R"EOF(
+        This operator checks whether the number of active interactions is consistent between the Classifier and the GridCellParticleInteraction.
+
+        YAML example:
+
+          - check_consistency_grid_classifier:
+             verbosity: true
+        )EOF";
+		}
+
+		std::string operator_name() { return "check_consistency_grid_classifier"; }
+
+		inline void execute() override final
+		{
+			auto& classifier = *ic;
+			auto& grid = *ges;
+
+			struct InteractionCounter 
+			{
+				std::array<uint64_t, Classifier<InteractionSOA>::types> counts_by_type = {};
+			};
+
+			auto extract_data = [] (InteractionCounter& input_counter, const Interaction& I) -> void
+			{
+				if(I.is_active())
+				{
+					input_counter.counts_by_type[I.type] += 1;
+				}
+			};
+
+			InteractionCounter classifier_side;
+			InteractionCounter grid_side;
+			// get data from classifier;
+
+			// Note : Sequential 
+			// Classifier
+			for(int i = 0; i < Classifier<InteractionSOA>::types ; i++)
+			{
+				auto [data, size] = classifier.get_info(i);
+				for(size_t j = 0; j < size ; j++)
+				{
+					Interaction I = data[j];
+					extract_data(classifier_side, I);
+				}
+			}
+			// GridCellParticleInteraction
+			auto &ces = grid.m_data;
+			for(size_t i = 0; i < ces.size(); i++)
+			{
+				auto &interactions = ces[i];
+				const unsigned int n_interactions_in_cell = interactions.m_data.size();
+				exaDEM::Interaction *const __restrict__ data_ptr = interactions.m_data.data();
+				for (size_t it = 0; it < n_interactions_in_cell; it++)
+				{
+					const Interaction &I = data_ptr[it];
+					extract_data(grid_side, I);
+				}
+			}
+
+			// Verify values
+			bool error = false;
+			for(int i = 0; i < Classifier<InteractionSOA>::types ; i++)
+			{
+				if(grid_side.counts_by_type[i] != classifier_side.counts_by_type[i])
+				{
+					std::string msg = "Mismatch in the number of interactions for type ";
+					msg += std::to_string(i);
+					msg += ": the classifier reports ";
+					msg += std::to_string(classifier_side.counts_by_type[i]);
+					msg += " active interactions, while GridCellParticleInteraction reports ";
+					msg += std::to_string(grid_side.counts_by_type[i]);
+					msg += ".";
+					color_log::warning(operator_name(), msg); 
+          error = true;
+				}
+			} 
+			if(error) color_log::error(operator_name(), "The number of active interactions between the classifier and the GridCellParticleInteraction is inconsistent. Ensure that this operator is invoked after the unclassify operator and before any compute_force call.");
+			if(*verbosity) color_log::highlight(operator_name(), "The classifier and the GridCellParticleInteraction contain the same active interactions. To disable this message, set the verbosity slot to false.");
+		}
+	};
+
+	// === register factories ===
+	ONIKA_AUTORUN_INIT(check_consistency_grid_classifier) 
+	{ 
+		OperatorNodeFactory::instance()->register_factory("check_consistency_grid_classifier", make_simple_operator<CheckConsistencyGridClassifier>); 
+	}
+} // namespace exaDEM

--- a/src/interaction/compress_interaction.cpp
+++ b/src/interaction/compress_interaction.cpp
@@ -51,7 +51,7 @@ namespace exaDEM
     inline void execute() override final
     {
       auto &cell_interactions = ges->m_data;
-      auto save = [](const exaDEM::Interaction &interaction) { return interaction.is_active(); };
+      auto save = [](const exaDEM::Interaction &interaction) -> bool { return interaction.is_active(); };
 
 #     pragma omp parallel for
       for (size_t current_cell = 0; current_cell < cell_interactions.size(); current_cell++)

--- a/src/interaction/include/exaDEM/interaction/interaction.hpp
+++ b/src/interaction/include/exaDEM/interaction/interaction.hpp
@@ -89,152 +89,160 @@ namespace exaDEM
      * @brief return true if particles id and particles sub id are equals.
      */
     ONIKA_HOST_DEVICE_FUNC bool operator==(Interaction &I)
-    {
-      if (this->id_i == I.id_i && this->id_j == I.id_j && this->sub_i == I.sub_i && this->sub_j == I.sub_j && this->type == I.type)
-      {
-        return true;
-      }
-      else
-      {
-        return false;
-      }
-    }
+		{
+			if (this->id_i == I.id_i && 
+					this->id_j == I.id_j && 
+					this->sub_i == I.sub_i && 
+					this->sub_j == I.sub_j && 
+					this->type == I.type)
+			{
+				return true;
+			}
+			else
+			{
+				return false;
+			}
+		}
 
-    /**
-     * @brief return true if particles id and particles sub id are equals.
-     */
-    ONIKA_HOST_DEVICE_FUNC bool operator==(const Interaction &I) const
-    {
-      if (this->id_i == I.id_i && this->id_j == I.id_j && this->sub_i == I.sub_i && this->sub_j == I.sub_j && this->type == I.type)
-      {
-        return true;
-      }
-      else
-      {
-        return false;
-      }
-    }
+		/**
+		 * @brief return true if particles id and particles sub id are equals.
+		 */
+		ONIKA_HOST_DEVICE_FUNC bool operator==(const Interaction &I) const
+		{
+			if (this->id_i == I.id_i && 
+					this->id_j == I.id_j && 
+					this->sub_i == I.sub_i && 
+					this->sub_j == I.sub_j && 
+					this->type == I.type)
+			{
+				return true;
+			}
+			else
+			{
+				return false;
+			}
+		}
 
-    ONIKA_HOST_DEVICE_FUNC bool operator<(const Interaction &I) const
-    {
-      if (this->id_i < I.id_i)
-      {
-        return true;
-      }
-      else if (this->id_i == I.id_i && this->id_j < I.id_j)
-      {
-        return true;
-      }
-      else if (this->id_i == I.id_i && this->id_j == I.id_j && this->sub_i < I.sub_i)
-      {
-        return true;
-      }
-      else if (this->id_i == I.id_i && this->id_j == I.id_j && this->sub_i == I.sub_i && this->sub_j < I.sub_j)
-      {
-        return true;
-      }
-      else if (this->id_i == I.id_i && this->id_j == I.id_j && this->sub_i == I.sub_i && this->sub_j == I.sub_j && this->type < I.type)
-      {
-        return true;
-      }
-      else
-        return false;
-    }
+		ONIKA_HOST_DEVICE_FUNC bool operator<(const Interaction &I) const
+		{
+			if (this->id_i < I.id_i)
+			{
+				return true;
+			}
+			else if (this->id_i == I.id_i && this->id_j < I.id_j)
+			{
+				return true;
+			}
+			else if (this->id_i == I.id_i && this->id_j == I.id_j && this->sub_i < I.sub_i)
+			{
+				return true;
+			}
+			else if (this->id_i == I.id_i && this->id_j == I.id_j && this->sub_i == I.sub_i && this->sub_j < I.sub_j)
+			{
+				return true;
+			}
+			else if (this->id_i == I.id_i && this->id_j == I.id_j && this->sub_i == I.sub_i && this->sub_j == I.sub_j && this->type < I.type)
+			{
+				return true;
+			}
+			else
+				return false;
+		}
 
-    ONIKA_HOST_DEVICE_FUNC void update(Interaction &I)
-    {
-      this->cell_i = I.cell_i;
-      this->cell_j = I.cell_j;
-      this->p_i = I.p_i;
-      this->p_j = I.p_j;
-    }
+		ONIKA_HOST_DEVICE_FUNC void update(Interaction &I)
+		{
+			this->cell_i = I.cell_i;
+			this->cell_j = I.cell_j;
+			this->p_i = I.p_i;
+			this->p_j = I.p_j;
+		}
 
-    ONIKA_HOST_DEVICE_FUNC void update_friction_and_moment(Interaction &I)
-    {
-      this->friction = I.friction;
-      this->moment = I.moment;
-    }
-  };
+		ONIKA_HOST_DEVICE_FUNC void update_friction_and_moment(Interaction &I)
+		{
+			this->friction = I.friction;
+			this->moment = I.moment;
+		}
+	};
 
-  inline std::pair<bool, Interaction &> get_interaction(std::vector<Interaction> &list, Interaction &I)
-  {
-    auto iterator = std::find(list.begin(), list.end(), I);
-    // assert(iterator == std::end(list) && "This interaction is NOT in the list");
-    bool exist = iterator == std::end(list);
-    return {exist, *iterator};
-  }
+	inline std::pair<bool, Interaction &> get_interaction(std::vector<Interaction> &list, Interaction &I)
+	{
+		auto iterator = std::find(list.begin(), list.end(), I);
+		// assert(iterator == std::end(list) && "This interaction is NOT in the list");
+		bool exist = iterator == std::end(list);
+		return {exist, *iterator};
+	}
 
-  inline std::vector<Interaction> extract_history_omp(std::vector<Interaction> &interactions)
-  {
-    std::vector<Interaction> ret;
+	inline std::vector<Interaction> extract_history_omp(std::vector<Interaction> &interactions)
+	{
+		std::vector<Interaction> ret;
 #   pragma omp parallel
-    {
-      std::vector<Interaction> tmp;
+		{
+			std::vector<Interaction> tmp;
 #     pragma omp for
-      for (size_t i = 0; i < interactions.size(); i++)
-      {
-        if (interactions[i].is_active())
-        {
-          tmp.push_back(interactions[i]);
-        }
-      }
+			for (size_t i = 0; i < interactions.size(); i++)
+			{
+				if (interactions[i].is_active())
+				{
+					tmp.push_back(interactions[i]);
+				}
+			}
 
-      if (tmp.size() > 0)
-      {
+			if (tmp.size() > 0)
+			{
 #       pragma omp critical
-        {
-          ret.insert(ret.end(), tmp.begin(), tmp.end());
-        }
-      }
-    }
+				{
+					ret.insert(ret.end(), tmp.begin(), tmp.end());
+				}
+			}
+		}
 
-    return ret;
-  }
+		return ret;
+	}
 
-  inline void update_friction_moment_omp(std::vector<Interaction> &interactions, std::vector<Interaction> &history)
-  {
+	inline void update_friction_moment_omp(std::vector<Interaction> &interactions, std::vector<Interaction> &history)
+	{
 #   pragma omp parallel for
-    for (size_t it = 0; it < interactions.size(); it++)
-    {
-      auto &item = interactions[it];
-      auto lower = std::lower_bound(history.begin(), history.end(), item);
-      if (lower != history.end())
-      {
-        if (item == *lower)
-        {
-          item.update_friction_and_moment(*lower);
-        }
-      }
-    }
-  }
+		for (size_t it = 0; it < interactions.size(); it++)
+		{
+			auto &item = interactions[it];
+			auto lower = std::lower_bound(history.begin(), history.end(), item);
+			if (lower != history.end())
+			{
+				if (item == *lower)
+				{
+					item.update_friction_and_moment(*lower);
+				}
+			}
+		}
+	}
 
-  inline void update_friction_moment(std::vector<Interaction> &interactions, std::vector<Interaction> &history)
-  {
-    for (size_t it = 0; it < interactions.size(); it++)
-    {
-      auto &item = interactions[it];
-      auto lower = std::lower_bound(history.begin(), history.end(), item);
-      if (lower != history.end())
-      {
-        if (item == *lower)
-        {
-          item.update_friction_and_moment(*lower);
-        }
-      }
-    }
-  }
+	inline void update_friction_moment(std::vector<Interaction> &interactions, std::vector<Interaction> &history)
+	{
+		for (size_t it = 0; it < interactions.size(); it++)
+		{
+			auto &item = interactions[it];
+			auto lower = std::lower_bound(history.begin(), history.end(), item);
+			if (lower != history.end())
+			{
+				if (item == *lower)
+				{
+					item.update_friction_and_moment(*lower);
+				}
+			}
+		}
+	}
 
-  // sequential
-  inline void extract_history(std::vector<Interaction> &local, const Interaction *data, const unsigned int size)
-  {
-    local.clear();
-    for (size_t i = 0; i < size; i++)
-    {
-      const auto &item = data[i];
-      if (item.is_active())
-      {
-        local.push_back(item);
-      }
-    }
-  }
+	// sequential
+	inline void extract_history(std::vector<Interaction> &local, const Interaction *data, const unsigned int size)
+	{
+		local.clear();
+		for (size_t i = 0; i < size; i++)
+		{
+			const auto &item = data[i];
+			if (item.is_active())
+			{
+				local.push_back(item);
+			}
+		}
+	}
 } // namespace exaDEM

--- a/src/polyhedron/nbh_polyhedron.cpp
+++ b/src/polyhedron/nbh_polyhedron.cpp
@@ -125,7 +125,10 @@ namespace exaDEM
           assert(interaction_test::check_extra_interaction_storage_consistency(storage.number_of_particles(), storage.m_info.data(), storage.m_data.data()));
 
           if (n_particles == 0)
+          {
+            storage.initialize(0);
             continue;
+          }
 
           // Extract history before reset it
           const size_t data_size = storage.m_data.size();


### PR DESCRIPTION
New:

- Operator `check_consistency_grid_classifier` (execution is stopped if the number of active interactions is not the same in the classifier and in the grid interactions).
- Fixed an issue where the interaction `cell_i` and `cell_j` were inverted. See `unclassify`.
- Interactions are reset in the grid when they are classified in the classifier. See `classify`.

How to use it:

In the global operator block, add : `active_interaction_checker: true`

or 

```
compress_data:
  - unclassify_interactions
  - compress_interaction
  - check_consistency_grid_classifier:
     verbosity: true
```
Output :

<img width="1655" height="654" alt="error" src="https://github.com/user-attachments/assets/7568fc43-7d95-46ec-a607-b11a1245dd15" />

