### PR TITLE
grid_cell_values update (or not) when doing ghost_update

### DIFF
--- a/src/grid/update_ghosts.cu
+++ b/src/grid/update_ghosts.cu
@@ -48,10 +48,18 @@ using UpdateGhostsRQ =
     UpdateGhostsNode<GridT,
                      AddDefaultFields<FieldSet<field::_rx, field::_ry, field::_rz, field::_vx, field::_vy, field::_vz, field::_type,
                               field::_radius, field::_mass, field::_vrot, field::_orient>>,
-                     false>;
+                     false, true>;
 
+template <typename GridT>
+using UpdateGhostsRQNoGCV =
+    UpdateGhostsNode<GridT,
+                     AddDefaultFields<FieldSet<field::_rx, field::_ry, field::_rz, field::_vx, field::_vy, field::_vz, field::_type,
+                              field::_radius, field::_mass, field::_vrot, field::_orient>>,
+                     false, false>;
+  
 // === register factory ===
 ONIKA_AUTORUN_INIT(update_ghosts) {
   OperatorNodeFactory::instance()->register_factory("ghost_update_rq", make_grid_variant_operator<UpdateGhostsRQ>);
+  OperatorNodeFactory::instance()->register_factory("ghost_update_rq_no_gcv", make_grid_variant_operator<UpdateGhostsRQNoGCV>);  
 }
 }  // namespace exaDEM


### PR DESCRIPTION

Here is the operators that are added 

```bash
# Update RQ and update grid_cell_values
ghost_update_rq
# Update RQ and DO NOT update grid_cell_values
ghost_update_rq_no_gcv
```

This should be merged after PR 142  in exaNBody is merged : 

https://github.com/Collab4exaNBody/exaNBody/pull/142
